### PR TITLE
Make SecretsManager Work

### DIFF
--- a/app/src/main/kotlin/RequestHandler.kt
+++ b/app/src/main/kotlin/RequestHandler.kt
@@ -18,13 +18,13 @@ class RequestHandler(
 
     suspend fun handle(request: ServerRequest): ServerResponse {
         // FIXME: WebFilter
-        val apiKey = runCatching {
-            requireNotNull(request.headers().firstHeader("x-api-key"))
+        val client = runCatching {
+            val apiKey = requireNotNull(request.headers().firstHeader("x-api-key"))
+            requireNotNull(clientRegistry.findByApiKey(apiKey))
         }.getOrElse {
             return ServerResponse.status(HttpStatus.UNAUTHORIZED).bodyValueAndAwait(Unit)
         }
 
-        val client = clientRegistry.findByApiKey(apiKey)
         val event = request.awaitBody<TruffleEvent>().also { it.client = client }
 
         eventBus.publish(event)

--- a/core/src/main/kotlin/TruffleClient.kt
+++ b/core/src/main/kotlin/TruffleClient.kt
@@ -1,5 +1,6 @@
 package io.wafflestudio.truffle.core
 
 data class TruffleClient(
-    val channelName: String,
+    val name: String,
+    val slackChannel: String,
 )

--- a/core/src/main/kotlin/TruffleClientProperties.kt
+++ b/core/src/main/kotlin/TruffleClientProperties.kt
@@ -1,0 +1,8 @@
+package io.wafflestudio.truffle.core
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("truffle.client")
+data class TruffleClientProperties(
+    val apiKeys: Map<String, String>,
+)

--- a/core/src/main/kotlin/TruffleClientProperties.kt
+++ b/core/src/main/kotlin/TruffleClientProperties.kt
@@ -4,5 +4,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("truffle.client")
 data class TruffleClientProperties(
-    val apiKeys: Map<String, String>,
+    val info: Map<String, TruffleClientInfo>,
+)
+
+data class TruffleClientInfo(
+    val apiKey: String,
+    val slackChannel: String,
 )

--- a/core/src/main/kotlin/TruffleClientRegistry.kt
+++ b/core/src/main/kotlin/TruffleClientRegistry.kt
@@ -1,11 +1,12 @@
 package io.wafflestudio.truffle.core
 
-import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Service
 
+@EnableConfigurationProperties(TruffleClientProperties::class)
 @Service
 class TruffleClientRegistry(
-    @Value("\${truffle.client}") private val clientMap: Map<String, String> = emptyMap(),
+    private val clientProperties: TruffleClientProperties,
 ) {
-    fun findByApiKey(apiKey: String): TruffleClient? = clientMap[apiKey]?.let(::TruffleClient)
+    fun findByApiKey(apiKey: String): TruffleClient? = clientProperties.apiKeys[apiKey]?.let(::TruffleClient)
 }

--- a/core/src/main/kotlin/TruffleClientRegistry.kt
+++ b/core/src/main/kotlin/TruffleClientRegistry.kt
@@ -6,7 +6,11 @@ import org.springframework.stereotype.Service
 @EnableConfigurationProperties(TruffleClientProperties::class)
 @Service
 class TruffleClientRegistry(
-    private val clientProperties: TruffleClientProperties,
+    clientProperties: TruffleClientProperties,
 ) {
-    fun findByApiKey(apiKey: String): TruffleClient? = clientProperties.apiKeys[apiKey]?.let(::TruffleClient)
+    private val apiKeyToClient = clientProperties.info.entries.associate { (name, info) ->
+        info.apiKey to TruffleClient(name, info.slackChannel)
+    }
+
+    fun findByApiKey(apiKey: String): TruffleClient? = apiKeyToClient[apiKey]
 }

--- a/core/src/main/kotlin/config/SecretsManagerConfig.kt
+++ b/core/src/main/kotlin/config/SecretsManagerConfig.kt
@@ -1,28 +1,35 @@
 package io.wafflestudio.truffle.core.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.context.EnvironmentAware
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import org.springframework.core.env.Environment
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
 
 @Configuration
 @Profile("!test")
-class SecretsManagerConfig(
-    @Value("\${secret-names}") private val secretNames: String,
-    private val objectMapper: ObjectMapper,
-) : BeanFactoryPostProcessor {
-    override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
-        val region = Region.AP_NORTHEAST_2
+class SecretsManagerConfig : EnvironmentAware, BeanFactoryPostProcessor {
+    private lateinit var env: Environment
 
-        secretNames.split(",").forEach { secretName ->
+    override fun setEnvironment(environment: Environment) {
+        env = environment
+    }
+
+    override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
+        val secretNames = env.getProperty("secret-names", "").split(",")
+        val region = Region.AP_NORTHEAST_2
+        val objectMapper = jacksonObjectMapper()
+
+        secretNames.forEach { secretName ->
             val secretString = getSecretString(secretName, region)
             val map = objectMapper.readValue<Map<String, String>>(secretString)
+            map.forEach { (key, value) -> System.setProperty(key, value) }
         }
     }
 

--- a/core/src/main/kotlin/transport/slack/SlackProperties.kt
+++ b/core/src/main/kotlin/transport/slack/SlackProperties.kt
@@ -2,7 +2,7 @@ package io.wafflestudio.truffle.core.transport.slack
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties("transport.slack.channels")
+@ConfigurationProperties("transport.slack")
 data class SlackProperties(
     val token: String,
 )

--- a/core/src/main/kotlin/transport/slack/SlackTransport.kt
+++ b/core/src/main/kotlin/transport/slack/SlackTransport.kt
@@ -24,7 +24,7 @@ class SlackTransport(
         runCatching {
             suspendCoroutine { cont ->
                 val future = slackClient.filesUpload { builder ->
-                    builder.channels(listOf(event.client!!.channelName)) // FIXME !!
+                    builder.channels(listOf(event.client!!.slackChannel)) // FIXME !!
                         .filetype("text")
                         .filename("TODO.txt") // event.app + time ->
                         .content("TODO") // event ->

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring.profiles.active: local
 
 secret-names: dev/truffle
+
+transport:
+  slack:
+    enabled: true
+    token:


### PR DESCRIPTION
<img width="1258" alt="스크린샷 2023-01-10 11 07 31" src="https://user-images.githubusercontent.com/35535636/211445834-91dbaee7-b7bb-4436-9b4e-cee0ab45e72a.png">

이런 식으로 넣으면 돌아가게 만들어둠. `transport.slack.token`은 가짜임.

물론 나중에 AWS SecretsManager 보다 더 좋은 방식이 있으면 언제든 바꿔도 좋습니다.

`SecretsManagerConfig`가 `EnvironmentAware, BeanFactoryPostProcessor`를 다 상속하고 있어서 마음이 아픈데, 기존처럼 짜면 default constructor 없어서 아예 뜨지도 못하고 고민들이 있어서, 우선 급한대로 돌아가게 고치는 것에 집중했습니다.

단 이렇게 하면, SecretsManager 접근 권한이 없는 사람은 서버 띄우지도 못합니다.
