### PR TITLE
add description to eventV1, allow empty exception.elements

### DIFF
--- a/app/src/integrationTest/kotlin/SlackTest.kt
+++ b/app/src/integrationTest/kotlin/SlackTest.kt
@@ -54,6 +54,7 @@ class SlackTest @Autowired constructor(
                 )
             )
         ),
+        description = "description",
         version = TruffleVersion.V1
     )
 }

--- a/app/src/main/kotlin/RequestHandler.kt
+++ b/app/src/main/kotlin/RequestHandler.kt
@@ -17,18 +17,6 @@ class RequestHandler(
     suspend fun handle(request: ServerRequest): ServerResponse {
         val event = request.awaitBody<TruffleEvent>()
 
-        when (event) {
-            is TruffleEvent.V1 -> {
-                if (event.exception.elements.isEmpty()) {
-                    return ServerResponse.badRequest().bodyValueAndAwait(Unit)
-                }
-            }
-
-            else -> {
-                TODO("This code should be unreachable")
-            }
-        }
-
         event.client = request.attribute("client").get() as TruffleClient // This should not fail.
 
         eventBus.publish(event)

--- a/core/src/main/kotlin/TruffleEvent.kt
+++ b/core/src/main/kotlin/TruffleEvent.kt
@@ -18,6 +18,7 @@ interface TruffleEvent {
         val app: TruffleApp,
         val runtime: TruffleRuntime,
         val exception: TruffleException,
+        val description: String? = null,
         override val version: String = TruffleVersion.V1,
     ) : TruffleEvent {
         override var client: TruffleClient? = null // FIXME

--- a/core/src/main/kotlin/transport/slack/SlackTransport.kt
+++ b/core/src/main/kotlin/transport/slack/SlackTransport.kt
@@ -38,16 +38,22 @@ class SlackTransport(
 
         if (event is TruffleEvent.V1) {
             filetype("text")
-            title("${client.name}_${LocalDateTime.now()}.txt")
+            title("${event.app.name}-${event.app.phase}_${LocalDateTime.now()}.txt")
             channels(listOf(client.slackChannel))
             content(
                 buildString {
-                    event.exception.elements.forEach {
-                        appendLine("${it.className} in ${it.methodName} at line ${it.lineNumber}")
+                    val elements = event.exception.elements
+
+                    if (elements.isNotEmpty()) {
+                        elements.forEach {
+                            appendLine("${it.className} in ${it.methodName} at line ${it.lineNumber}")
+                        }
+                    } else {
+                        appendLine()
                     }
                 }
             )
-            initialComment("${event.exception.className} : ${event.exception.message}")
+            initialComment("${event.exception.className} : ${event.exception.message}\n${event.description ?: ""}")
         }
 
         return this

--- a/core/src/test/kotlin/EventSerializeTest.kt
+++ b/core/src/test/kotlin/EventSerializeTest.kt
@@ -35,6 +35,7 @@ class EventSerializeTest {
                     )
                 )
             ),
+            description = "description",
             version = "v1"
         )
 


### PR DESCRIPTION
- 부가 정보를 위한 description 프로퍼티 추가.
- TurffleException.Elements이 비어도 동작하도록 수정.